### PR TITLE
Added HibernationEntry support

### DIFF
--- a/ArkSavegameToolkitNet.TestConsoleApp/Program.cs
+++ b/ArkSavegameToolkitNet.TestConsoleApp/Program.cs
@@ -10,13 +10,14 @@ namespace ArkSavegameToolkitNet.TestConsoleApp
     {
         static void Main(string[] args)
         {
-            var savePath = @"C:\save\TheIsland.ark";
+            var savePath = @"C:\save\NoHibernation\TheIsland.ark";
+           // var savePath = @"C:\save\WithHibernation\TheIsland.ark";
             var clusterPath = @"C:\save\cluster";
             var domainOnly = true; //true: optimize loading of the domain model, false: load everything and keep references in memory
 
             //prepare
             var cd = new ArkClusterData(clusterPath, loadOnlyPropertiesInDomain: domainOnly);
-            var gd = new ArkGameData(savePath, cd, loadOnlyPropertiesInDomain: domainOnly);
+            var gd = new ArkGameData(savePath, cd,1, loadOnlyPropertiesInDomain: domainOnly);
 
             var st = Stopwatch.StartNew();
             //extract savegame
@@ -25,8 +26,9 @@ namespace ArkSavegameToolkitNet.TestConsoleApp
                 Console.WriteLine($@"Elapsed (gd) {st.ElapsedMilliseconds:N0} ms");
                 st = Stopwatch.StartNew();
 
-                //extract cluster data
-                var clusterResult = cd.Update(CancellationToken.None);
+                //extract cluster data: no cluster data exists for singlePlayer
+                ArkClusterDataUpdateResult clusterResult;
+                if (System.IO.File.Exists(clusterPath)) clusterResult = cd.Update(CancellationToken.None);
 
                 Console.WriteLine($@"Elapsed (cd) {st.ElapsedMilliseconds:N0} ms");
                 st = Stopwatch.StartNew();

--- a/ArkSavegameToolkitNet/ArkSavegameToolkitNet.csproj
+++ b/ArkSavegameToolkitNet/ArkSavegameToolkitNet.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Exceptions\UnreadablePropertyException.cs" />
     <Compile Include="GameObjectReader.cs" />
     <Compile Include="GameObject.cs" />
+    <Compile Include="HibernationEntry.cs" />
     <Compile Include="ICloudInventoryDinoData.cs" />
     <Compile Include="ISaveState.cs" />
     <Compile Include="Property\ExcludedProperty.cs" />

--- a/ArkSavegameToolkitNet/HibernationEntry.cs
+++ b/ArkSavegameToolkitNet/HibernationEntry.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ArkSavegameToolkitNet
+{
+    public class HibernationEntry
+    {
+        public IEnumerable<GameObject> Objects
+        {
+           get
+            {
+                return _objects;
+            }
+        }
+
+        private List<GameObject> _objects = new List<GameObject>();
+        private List<string> _zoneVolumes = new List<string>();
+        private  List<string> _nameTable = new List<string>();
+        public int _classIndex;
+        public HibernationEntry(ArkArchive archive)
+        {
+            readBinary(archive);
+        }
+
+        public void readBinary(ArkArchive archive)
+        {
+            var x = archive.GetFloat();
+            var y = archive.GetFloat();
+            var z = archive.GetFloat();
+            var unkByte = archive.GetByte();
+            var unkFloat = archive.GetFloat();
+            var nameArchiveSize = archive.GetInt();
+            var nameArchive = archive.Slice( archive.Position, nameArchiveSize);
+            readBinaryNameTable(nameArchive);
+            archive.Position += nameArchiveSize;
+            var objectArchiveSize = archive.GetInt();
+            var objectArchive = archive.Slice( archive.Position, objectArchiveSize);
+            readBinaryObjects(objectArchive);
+            archive.Position += objectArchiveSize;
+            var unkInt1 = archive.GetInt();
+            _classIndex = archive.GetInt();
+        }
+
+        private void readBinaryNameTable(ArkArchive archive)
+        {
+            var version = archive.GetInt();
+            if (version != 3)
+                throw new NotSupportedException($"hibernation version not supported <>3");
+            var nameCount = archive.GetInt();
+            for (int i = 0; i <= nameCount - 1; i++)
+            {
+                _nameTable.Add(archive.GetString());
+            }
+
+            var zoneCount = archive.GetInt();
+            for (int i = 0; i <= zoneCount - 1; i++)
+            {
+                _zoneVolumes.Add(archive.GetString());
+            }
+        }
+
+        private void readBinaryObjects(ArkArchive archive)
+        {
+            var objectCount = archive.GetInt();
+            for (int i = 0; i <= objectCount - 1; i++)
+            {
+                var go = new GameObject(archive);
+                go.ObjectId = i;
+                _objects.Add(go);
+            }
+
+            archive.SetNameTable(_nameTable, 0, true);
+            for (int n = 0; n <= objectCount - 1; n++)
+            {
+                var go = _objects[n];
+                _objects[n].loadProperties(archive, (n < _objects.Count - 1) ? _objects[n + 1] : null, 0);
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"HibernationEntry: Objects: {_objects.Count} ClassIndex:{_classIndex}";
+        }
+    }
+}


### PR DESCRIPTION
As discussed:
- hibernationEntries support added with arkNameCache shuffling
- changed program.cs for testing and singleplayer support
- tested against saves with and without hibarnation

Todo:
- adapt ArkSavegameToolkitNet.Domain to reflect objects in hibernationEntries
- improve performance by parallel execution of hibernation entries (more refactoring needed)

Sugggestions:
- make arkNameCache static (it is in qowyns code already) or move caching to ArkName .
 Cache can be reset in LoadEverything or Dispose if you are worried about memory, but there are just about 80k entries.
- ArkArchive is tightly coupled to memoryMappedFile. ArkArchive should just depend on fileName and should be interfaced to allow different implementations. F.e. loading the file into a ByteBuffer and using BitConverter methods is definitely faster (~1 second)
- no measurable performance improvements with excludedPropertiesTree
- use an options class to encapsulate savegame options
- a lot of unused code / classes (GameObjectReader?)

Cheers

