### PR TITLE
Introduce GetSByte and GetSBytes to ArkArchive; handle sbyte and byte scenarios

### DIFF
--- a/ArkSavegameToolkitNet/ArkArchive.cs
+++ b/ArkSavegameToolkitNet/ArkArchive.cs
@@ -254,11 +254,7 @@ namespace ArkSavegameToolkitNet
         public int GetInt(long position)
         {
             const long size = 4;
-            if (position + size > _size)
-            {
-                _logger.Error($"Trying to read {size} bytes at {position:X} with just {_size - position} bytes left");
-                throw new OverflowException();
-            }
+            CheckForOverflow(size);
 
             var value = _va.ReadInt32(position);
 
@@ -268,27 +264,18 @@ namespace ArkSavegameToolkitNet
         public int GetInt()
         {
             const long size = 4;
-            if (_position + size > _size)
-            {
-                _logger.Error($"Trying to read {size} bytes at {_position:X} with just {_size - _position} bytes left");
-                throw new OverflowException();
-            }
+            CheckForOverflow(size);
 
             var value = _va.ReadInt32(_position);
             _position += size;
 
             return value;
         }
-
-        public sbyte[] GetBytes(int length)
+        
+        public byte[] GetBytes(int length)
         {
-            var buffer = new sbyte[length];
-
-            if (_position + length > _size)
-            {
-                _logger.Error($"Trying to read {length} bytes at {_position:X} with just {_size - _position} bytes left");
-                throw new OverflowException();
-            }
+            var buffer = new byte[length];
+            CheckForOverflow(length);
 
             var value = _va.ReadArray(_position, buffer, 0, length);
             _position += length;
@@ -296,14 +283,32 @@ namespace ArkSavegameToolkitNet
             return buffer;
         }
 
-        public sbyte GetByte()
+        public byte GetByte()
         {
             const long size = 1;
-            if (_position + size > _size)
-            {
-                _logger.Error($"Trying to read {size} bytes at {_position:X} with just {_size - _position} bytes left");
-                throw new OverflowException();
-            }
+            CheckForOverflow(size);
+
+            var value = _va.ReadByte(_position);
+            _position += size;
+
+            return value;
+        }
+
+        public sbyte[] GetSBytes(int length)
+        {
+            var buffer = new sbyte[length];
+            CheckForOverflow(length);
+
+            var value = _va.ReadArray(_position, buffer, 0, length);
+            _position += length;
+
+            return buffer;
+        }
+
+        public sbyte GetSByte()
+        {
+            const long size = 1;
+            CheckForOverflow(size);
 
             var value = _va.ReadSByte(_position);
             _position += size;
@@ -314,11 +319,7 @@ namespace ArkSavegameToolkitNet
         public long GetLong()
         {
             const long size = 8;
-            if (_position + size > _size)
-            {
-                _logger.Error($"Trying to read {size} bytes at {_position:X} with just {_size - _position} bytes left");
-                throw new OverflowException();
-            }
+            CheckForOverflow(size);
 
             var value = _va.ReadInt64(_position);
             _position += size;
@@ -329,11 +330,7 @@ namespace ArkSavegameToolkitNet
         public short GetShort()
         {
             const long size = 2;
-            if (_position + size > _size)
-            {
-                _logger.Error($"Trying to read {size} bytes at {_position:X} with just {_size - _position} bytes left");
-                throw new OverflowException();
-            }
+            CheckForOverflow(size);
 
             var value = _va.ReadInt16(_position);
             _position += size;
@@ -344,11 +341,7 @@ namespace ArkSavegameToolkitNet
         public double GetDouble()
         {
             const long size = 8;
-            if (_position + size > _size)
-            {
-                _logger.Error($"Trying to read {size} bytes at {_position:X} with just {_size - _position} bytes left");
-                throw new OverflowException();
-            }
+            CheckForOverflow(size);
 
             var value = _va.ReadDouble(_position);
             _position += size;
@@ -359,11 +352,7 @@ namespace ArkSavegameToolkitNet
         public float GetFloat()
         {
             const long size = 4;
-            if (_position + size > _size)
-            {
-                _logger.Error($"Trying to read {size} bytes at {_position:X} with just {_size - _position} bytes left");
-                throw new OverflowException();
-            }
+            CheckForOverflow(size);
 
             var value = _va.ReadSingle(_position);
             _position += size;
@@ -377,6 +366,15 @@ namespace ArkSavegameToolkitNet
             if (val < 0 || val > 1) _logger.Warn($"Boolean at {_position:X} with value {val}, returning true.");
 
             return val != 0;
+        }
+
+        private void CheckForOverflow(long size)
+        {
+            if (_position + size > _size)
+            {
+                _logger.Error($"Trying to read {size} bytes at {_position:X} with just {_size - _position} bytes left");
+                throw new OverflowException();
+            }
         }
     }
 }

--- a/ArkSavegameToolkitNet/ArkLocalProfile.cs
+++ b/ArkSavegameToolkitNet/ArkLocalProfile.cs
@@ -47,7 +47,7 @@ namespace ArkSavegameToolkitNet
             }
         }
         private GameObject _localprofile;
-        private sbyte[] unknownData;
+        private byte[] unknownData;
         private ArkNameCache _arkNameCache;
         private ArkNameTree _exclusivePropertyNameTree;
         private string _fileName;

--- a/ArkSavegameToolkitNet/Arrays/ArkArrayBool.cs
+++ b/ArkSavegameToolkitNet/Arrays/ArkArrayBool.cs
@@ -17,10 +17,9 @@ namespace ArkSavegameToolkitNet.Arrays
             var size = archive.GetInt();
             Capacity = size;
 
-            for (int n = 0; n < size; n++)
-            {
-                Add(archive.GetByte() != 0);
-            }
+            AddRange(archive.GetBytes(size).Select(IsByteValueNotZero).Cast<bool?>().ToArray());
+
+            bool IsByteValueNotZero(byte b) => b != 0;
         }
 
         public Type ValueClass => typeof(bool?);

--- a/ArkSavegameToolkitNet/Arrays/ArkArrayByte.cs
+++ b/ArkSavegameToolkitNet/Arrays/ArkArrayByte.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ArkSavegameToolkitNet.Arrays
 {
-    public class ArkArrayByte : List<sbyte?>, IArkArray<sbyte?>
+    public class ArkArrayByte : List<byte?>, IArkArray<byte?>
     {
         public ArkArrayByte()
         {
@@ -23,13 +23,10 @@ namespace ArkSavegameToolkitNet.Arrays
                 throw new UnreadablePropertyException();
             }
 
-            for (int n = 0; n < size; n++)
-            {
-                Add(archive.GetByte());
-            }
+            AddRange(archive.GetBytes(size).Cast<byte?>().ToArray());
         }
 
-        public Type ValueClass => typeof(sbyte?);
+        public Type ValueClass => typeof(byte?);
 
         //public int calculateSize(bool nameTable)
         //{

--- a/ArkSavegameToolkitNet/Arrays/ArkArrayInt8.cs
+++ b/ArkSavegameToolkitNet/Arrays/ArkArrayInt8.cs
@@ -17,10 +17,7 @@ namespace ArkSavegameToolkitNet.Arrays
             var size = archive.GetInt();
             Capacity = size;
 
-            for (int n = 0; n < size; n++)
-            {
-                this.Add(archive.GetByte());
-            }
+            AddRange(archive.GetSBytes(size).Cast<sbyte?>().ToArray());
         }
 
         public Type ValueClass => typeof(sbyte?);

--- a/ArkSavegameToolkitNet/Data/ExtraDataBlob.cs
+++ b/ArkSavegameToolkitNet/Data/ExtraDataBlob.cs
@@ -11,7 +11,7 @@ namespace ArkSavegameToolkitNet.Data
     public class ExtraDataBlob : IExtraData
     {
         [JsonProperty]
-        public sbyte[] Data { get; set; }
+        public byte[] Data { get; set; }
 
         //public int calculateSize(bool nameTable)
         //{

--- a/ArkSavegameToolkitNet/Property/PropertyInt8.cs
+++ b/ArkSavegameToolkitNet/Property/PropertyInt8.cs
@@ -24,7 +24,7 @@ namespace ArkSavegameToolkitNet.Property
                 return;
             }
 
-            _value = archive.GetByte();
+            _value = archive.GetSByte();
         }
 
         //public override Type ValueClass => typeof(sbyte?);

--- a/ArkSavegameToolkitNet/Property/PropertyText.cs
+++ b/ArkSavegameToolkitNet/Property/PropertyText.cs
@@ -24,7 +24,7 @@ namespace ArkSavegameToolkitNet.Property
                 return;
             }
 
-            _value = System.Convert.ToBase64String((byte[])(Array)archive.GetBytes(DataSize));
+            _value = Convert.ToBase64String(archive.GetBytes(DataSize));
         }
 
         //public override Type ValueClass => typeof(string);

--- a/ArkSavegameToolkitNet/Structs/StructColor.cs
+++ b/ArkSavegameToolkitNet/Structs/StructColor.cs
@@ -12,19 +12,19 @@ namespace ArkSavegameToolkitNet.Structs
     public class StructColor : StructBase
     {
         [JsonProperty]
-        public sbyte B { get; set; }
+        public byte B { get; set; }
         [JsonProperty]
-        public sbyte G { get; set; }
+        public byte G { get; set; }
         [JsonProperty]
-        public sbyte R { get; set; }
+        public byte R { get; set; }
         [JsonProperty]
-        public sbyte A { get; set; }
+        public byte A { get; set; }
 
         public StructColor(ArkName structType) : base(structType)
         {
         }
 
-        public StructColor(ArkName structType, sbyte b, sbyte g, sbyte r, sbyte a) : base(structType)
+        public StructColor(ArkName structType, byte b, byte g, byte r, byte a) : base(structType)
         {
             B = b;
             G = g;
@@ -34,11 +34,11 @@ namespace ArkSavegameToolkitNet.Structs
 
         public StructColor(ArkArchive archive, ArkName structType) : base(structType)
         {
-
-            B = archive.GetByte();
-            G = archive.GetByte();
-            R = archive.GetByte();
-            A = archive.GetByte();
+            var BGRA = archive.GetBytes(4);
+            B = BGRA[0];
+            G = BGRA[1];
+            R = BGRA[2];
+            A = BGRA[3];
         }
 
         //public override int getSize(bool nameTable)

--- a/ArkSavegameToolkitNet/Types/ArkByteValue.cs
+++ b/ArkSavegameToolkitNet/Types/ArkByteValue.cs
@@ -12,7 +12,7 @@ namespace ArkSavegameToolkitNet.Types
     {
         private bool _fromEnum;
 
-        private sbyte _byteValue;
+        private byte _byteValue;
 
         private ArkName _enumName;
 
@@ -20,7 +20,7 @@ namespace ArkSavegameToolkitNet.Types
 
         public ArkByteValue() { }
 
-        public ArkByteValue(sbyte byteValue)
+        public ArkByteValue(byte byteValue)
         {
             _fromEnum = false;
             _enumName = ArkName.NONE_NAME;
@@ -47,7 +47,7 @@ namespace ArkSavegameToolkitNet.Types
         public bool FromEnum => _fromEnum;
 
         [JsonProperty]
-        public sbyte ByteValue
+        public byte ByteValue
         {
             get
             {
@@ -67,12 +67,7 @@ namespace ArkSavegameToolkitNet.Types
             _enumName = enumName;
             _nameValue = nameValue;
         }
-
-        //public int getSize(bool nameTable)
-        //{
-        //    return _fromEnum ? ArkArchive.GetNameLength(_nameValue, nameTable) : 1;
-        //}
-
+        
         public void read(ArkArchive archive, ArkName enumName, bool propertyIsExcluded = false)
         {
             _enumName = enumName;
@@ -88,12 +83,6 @@ namespace ArkSavegameToolkitNet.Types
                 else _byteValue = archive.GetByte();
             }
         }
-
-        //public void CollectNames(ISet<string> nameTable)
-        //{
-        //    nameTable.Add(_enumName.Name);
-        //    if (_fromEnum) nameTable.Add(_nameValue.Name);
-        //}
 
         public TypeCode GetTypeCode()
         {
@@ -112,42 +101,44 @@ namespace ArkSavegameToolkitNet.Types
 
         public sbyte ToSByte(IFormatProvider provider)
         {
-            return ByteValue;
+            var sbyteArray = new sbyte[1];
+            Buffer.BlockCopy(new[] { ByteValue }, 0, sbyteArray, 0, 1);
+            return sbyteArray[0];
         }
 
         public byte ToByte(IFormatProvider provider)
         {
-            return (byte)ByteValue;
+            return ByteValue;
         }
 
         public short ToInt16(IFormatProvider provider)
         {
-            return (short)ByteValue;
+            return ByteValue;
         }
 
         public ushort ToUInt16(IFormatProvider provider)
         {
-            return (ushort)ByteValue;
+            return ByteValue;
         }
 
         public int ToInt32(IFormatProvider provider)
         {
-            return (int)ByteValue;
+            return ByteValue;
         }
 
         public uint ToUInt32(IFormatProvider provider)
         {
-            return (uint)ByteValue;
+            return ByteValue;
         }
 
         public long ToInt64(IFormatProvider provider)
         {
-            return (long)ByteValue;
+            return ByteValue;
         }
 
         public ulong ToUInt64(IFormatProvider provider)
         {
-            return (ulong)ByteValue;
+            return ByteValue;
         }
 
         public float ToSingle(IFormatProvider provider)

--- a/ArkSavegameToolkitNet/Types/EmbeddedData.cs
+++ b/ArkSavegameToolkitNet/Types/EmbeddedData.cs
@@ -11,7 +11,7 @@ namespace ArkSavegameToolkitNet.Types
     public class EmbeddedData
     {
         [JsonProperty]
-        public virtual sbyte[][][] Data { get; set; }
+        public virtual byte[][][] Data { get; set; }
         [JsonProperty]
         public string Path { get; set; }
 
@@ -54,11 +54,11 @@ namespace ArkSavegameToolkitNet.Types
 
             var partCount = archive.GetInt();
 
-            Data = new sbyte[partCount][][];
+            Data = new byte[partCount][][];
             for (var part = 0; part < partCount; part++)
             {
                 var blobCount = archive.GetInt();
-                var partData = new sbyte[blobCount][];
+                var partData = new byte[blobCount][];
 
                 for (var blob = 0; blob < blobCount; blob++)
                 {


### PR DESCRIPTION
relates to issue\bug #7 

- Adds `GetSByte` and `GetSBytes` methods to `ArkArchive`
- Modify `GetByte` and `GetBytes` to return `byte` and `byte[]` in `ArkArchive`
- Handle usages of `GetByte` based on expectation

Handled some refactor concepts with iterating and castings and introduce private `CheckOverflow` helper method in `ArkArchive` for code reuse and handling.